### PR TITLE
Show the usage counter on edition and deletion pages

### DIFF
--- a/wagtailmedia/templates/wagtailmedia/media/confirm_delete.html
+++ b/wagtailmedia/templates/wagtailmedia/media/confirm_delete.html
@@ -1,11 +1,18 @@
 {% extends "wagtailadmin/base.html" %}
-{% load i18n %}
+{% load wagtailadmin_tags i18n %}
 {% block titletag %}{% blocktrans with title=media.title %}Delete {{ title }}{% endblocktrans %}{% endblock %}
 {% block content %}
     {% trans "Delete media file" as del_str %}
     {% include "wagtailadmin/shared/header.html" with title=del_str subtitle=media.title icon="media" %}
 
     <div class="nice-padding">
+        {% usage_count_enabled as uc_enabled %}
+        {% if uc_enabled %}
+            <div class="usagecount">
+                <a href="{{ media.usage_url }}">{% blocktrans count usage_count=media.get_usage.count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
+            </div>
+        {% endif %}
+
         <p>{% trans "Are you sure you want to delete this media file?" %}</p>
         <form action="{% url 'wagtailmedia:delete' media.id %}" method="POST" novalidate>
             {% csrf_token %}

--- a/wagtailmedia/templates/wagtailmedia/media/edit.html
+++ b/wagtailmedia/templates/wagtailmedia/media/edit.html
@@ -1,6 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
-{% load wagtailimages_tags %}
+{% load wagtailimages_tags wagtailadmin_tags %}
 {% block titletag %}{% blocktrans with title=media.title %}Editing {{ title }}{% endblocktrans %}{% endblock %}
 
 {% block extra_js %}
@@ -49,6 +49,14 @@
                 {% if media.file %}
                     <dt>{% trans "Filesize" %}</dt>
                     <dd>{% if filesize %}{{ filesize|filesizeformat }}{% else %}{% trans "File not found" %}{% endif %}</dd>
+                {% endif %}
+
+                {% usage_count_enabled as uc_enabled %}
+                {% if uc_enabled %}
+                    <dt>{% trans "Usage" %}</dt>
+                    <dd>
+                        <a href="{{ media.usage_url }}">{% blocktrans count usage_count=media.get_usage.count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
+                    </dd>
                 {% endif %}
             </dl>
         </div>

--- a/wagtailmedia/tests/test_views.py
+++ b/wagtailmedia/tests/test_views.py
@@ -468,6 +468,13 @@ class TestMediaDeleteView(TestCase, WagtailTestUtils):
         # Media should be deleted
         self.assertFalse(models.Media.objects.filter(id=self.media.id).exists())
 
+    @override_settings(WAGTAIL_USAGE_COUNT_ENABLED=True)
+    def test_usage_link(self):
+        response = self.client.get(reverse('wagtailmedia:delete', args=(self.media.id,)))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'wagtailmedia/media/confirm_delete.html')
+        self.assertIn('Used 0 times', str(response.content))
+
 
 class TestMediaChooserView(TestCase, WagtailTestUtils):
     def setUp(self):


### PR DESCRIPTION
This follows the `documents` and `images` behaviors to show the linked usage counter on the edition and the deletion confirmation page. It by the way fixes all tests.

For the reference, here is the documents ones:
- [confirmation_delete.html](https://github.com/wagtail/wagtail/blob/d483c8d46543cd75caac8d8b4067173646072c81/wagtail/documents/templates/wagtaildocs/documents/confirm_delete.html)
- [edit.html](https://github.com/wagtail/wagtail/blob/78b1372cd437cd880950e3d0a82dedef847d0862/wagtail/documents/templates/wagtaildocs/documents/edit.html#L54-L60)